### PR TITLE
clip issue's solution

### DIFF
--- a/config/AISHELL3/preprocess.yaml
+++ b/config/AISHELL3/preprocess.yaml
@@ -13,7 +13,7 @@ preprocessing:
     language: "zh"
   audio:
     sampling_rate: 22050
-    max_wav_value: 32768.0
+    max_wav_value: 32767.0
   stft:
     filter_length: 1024
     hop_length: 256

--- a/config/LJSpeech/preprocess.yaml
+++ b/config/LJSpeech/preprocess.yaml
@@ -13,7 +13,7 @@ preprocessing:
     language: "en"
   audio:
     sampling_rate: 22050
-    max_wav_value: 32768.0
+    max_wav_value: 32767.0
   stft:
     filter_length: 1024
     hop_length: 256

--- a/config/LJSpeech_paper/preprocess.yaml
+++ b/config/LJSpeech_paper/preprocess.yaml
@@ -13,7 +13,7 @@ preprocessing:
     language: "en"
   audio:
     sampling_rate: 22050
-    max_wav_value: 32768.0
+    max_wav_value: 32767.0
   stft:
     filter_length: 1024
     hop_length: 256

--- a/config/LibriTTS/preprocess.yaml
+++ b/config/LibriTTS/preprocess.yaml
@@ -13,7 +13,7 @@ preprocessing:
     language: "en"
   audio:
     sampling_rate: 22050
-    max_wav_value: 32768.0
+    max_wav_value: 32767.0
   stft:
     filter_length: 1024
     hop_length: 256


### PR DESCRIPTION
Simpler solution for clipping.
Clip noise https://github.com/ming024/FastSpeech2/issues/73#issue-916122995 is caused by multiplying 2^15(half of int16), while int16's range is [-2^15, 2^15-1], it caused during abs max value is positive.
This commit solves this by multiplying 2^15-1 instead of 2^15.